### PR TITLE
Fix 500 error if buddypress isn't installed

### DIFF
--- a/bbpvotes-buddypress.php
+++ b/bbpvotes-buddypress.php
@@ -78,7 +78,9 @@ function bbpvotes_buddypress_voted_activity($post_id,$user_id,$vote){
     }
      */
 
-    bp_activity_add( $args );
+    if(function_exists('bp_activity_add')){
+        bp_activity_add( $args );
+    }
 }
 
 


### PR DESCRIPTION
Running this on a site that is bbpress _only_ causes wp-ajax to return
a 500 error because bp_activity_add() doesn't exist.
